### PR TITLE
Force n_index to be parsed when empty string

### DIFF
--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -382,7 +382,10 @@ class ObjParser(Parser):
                     t_index = (int(parts[1]) - 1) if has_vt else None
                 except ValueError:
                     t_index = 0
-                n_index = (int(parts[2]) - 1) if has_vn else None
+                try:
+                    n_index = (int(parts[2]) - 1) if has_vn else None
+                except ValueError:
+                    n_index = 0
 
                 # Resolve negative index lookups
                 if v_index < 0:


### PR DESCRIPTION
I have an `.obj` file provided to me, but it cannot parse it as I get a traceback stating:

```python
~/.local/lib/python3.7/site-packages/pywavefront/obj.py in consume_faces(self, collected_faces)
    383                 except ValueError:
    384                     t_index = 0
--> 385                 n_index = (int(parts[2]) - 1) if has_vn else None
    386 
    387                 # Resolve negative index lookups

ValueError: invalid literal for int() with base 10: ''
```

My solution was to wrap the assignment for `n_index` in a try-except block as was done for `t_index`, which allowed the file to be successfully parsed.