### PR TITLE
collect faces by material

### DIFF
--- a/pywavefront/material.py
+++ b/pywavefront/material.py
@@ -84,6 +84,9 @@ class Material:
         self.vertex_format = ""
         self.vertices = []
 
+        # Default to not collect faces by material
+        self.faces = None
+
         self.gl_floats = None
 
     @property

--- a/pywavefront/obj.py
+++ b/pywavefront/obj.py
@@ -272,6 +272,7 @@ class ObjParser(Parser):
         collected_faces = []
         consumed_vertices = self.consume_faces(collected_faces if self.collect_faces else None)
         self.material.vertices += list(consumed_vertices)
+        self.material.faces = collected_faces if self.collect_faces else None
 
         if self.collect_faces:
             self.mesh.faces += list(collected_faces)


### PR DESCRIPTION
This behavior is only active when `collect_faces==True`. This flag indicates that the user is interested in playing with faces at the cost of additional memory. This change allows people to have the option to operate on faces that has a specific material. I definitely need this feature for my own project. Pushing this change in case other people may find it useful.