### PR TITLE
use the new unittest.mock as integrated in the standard library

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest mock
+        python -m pip install flake8 pytest
         python -m pip install -e .
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,1 @@
 pytest<5
-mock<3

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 import json
 import os
-import mock
+from unittest import mock
 import unittest
 from pathlib import Path
 


### PR DESCRIPTION
https://github.com/testing-cabal/mock

mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.